### PR TITLE
# feat: sistema de normalización de asignaturas con soporte para nombres ambiguos

### DIFF
--- a/utils/Scripts/dataTransfer_v2/core/normalizers.py
+++ b/utils/Scripts/dataTransfer_v2/core/normalizers.py
@@ -74,6 +74,21 @@ EQUIVALENCIAS_ASIGNATURAS = {
     "Organización, Sistemas y Métodos": "Técnicas de Organización y Métodos", #isp
     "Administración III": "Técnicas de Organización y Métodos",             #lcik
     "Costos e Ingeniería Económica": "Ingeniería Económica",                #ien
+    "Estadística I": "Probabilidad y Estadística",                           #imk
+    "Probabilidades y Estadística": "Probabilidad y Estadística",           #iin
+}
+
+# Equivalencias con contexto de carrera: (nombre_normalizado_sin_acentos, SIGLA_CARRERA) → nombre_canónico
+# Usar cuando el mismo nombre en Excel representa contenidos distintos según la carrera.
+EQUIVALENCIAS_POR_CARRERA: dict[tuple[str, str], str] = {
+    # "Estadística" en IEK comparte contenido con Materia 1 (Probabilidad y Estadística general)
+    ("estadistica", "IEK"): "Probabilidad y Estadística",
+    # "Estadística" en LGH y LCI es un contenido diferente (Materia 2 - Licenciaturas)
+    ("estadistica", "LGH"): "Estadistica LGH LCI",
+    ("estadistica", "LCI"): "Estadistica LGH LCI",
+    # "Emprendedorismo" en IEL e IEN es Materia 4 → mismo contenido que "Plan de Negocios"
+    ("emprendedorismo", "IEL"): "Plan de Negocios",
+    ("emprendedorismo", "IEN"): "Plan de Negocios",
 }
 
 
@@ -94,8 +109,10 @@ def normalizar_titulo_asignatura(titulo: str) -> str:
     
     # Mapear equivalencias/sinónimos usando el texto normalizado (minúsculas, sin tildes)
     titulo_norm = normalizar_texto(titulo)
-    if titulo_norm in EQUIVALENCIAS_ASIGNATURAS:
-        titulo = EQUIVALENCIAS_ASIGNATURAS[titulo_norm]
+    for clave_original, valor_canonico in EQUIVALENCIAS_ASIGNATURAS.items():
+        if normalizar_texto(clave_original) == titulo_norm:
+            titulo = valor_canonico
+            break
 
     # 2. Corregir typos (insensible a mayúsculas usando replace)
     for typo, correcto in TYPO_MAP.items():
@@ -118,6 +135,21 @@ def normalizar_titulo_asignatura(titulo: str) -> str:
     titulo = re.sub(r'\b([IVX]+)-', r'\1 - ', titulo)
     
     return titulo.strip()
+
+def normalizar_titulo_con_carrera(titulo: str, carrera_sigla: str) -> str:
+    """Como normalizar_titulo_asignatura pero con contexto de carrera.
+
+    Primero revisa si existe una equivalencia específica para (titulo, carrera_sigla)
+    en EQUIVALENCIAS_POR_CARRERA. Si no hay entrada, delega al flujo normal.
+    Usar en asignatura_service, malla_service y seccion_service.
+    """
+    clave = (normalizar_texto(titulo), carrera_sigla.strip().upper())
+    if clave in EQUIVALENCIAS_POR_CARRERA:
+        # Retornar directamente el nombre canónico sin pasar por normalizar_titulo_asignatura,
+        # ya que esa función elimina texto entre paréntesis y los nombres canónicos
+        # del dict contextual pueden contenerlos (ej. "Estadística (LGH, LCI)").
+        return EQUIVALENCIAS_POR_CARRERA[clave].strip()
+    return normalizar_titulo_asignatura(titulo)
 
 def es_duplicado_fuzzy(nombre_a: str, nombre_b: str, umbral: int = 92) -> bool:
     """Fuzzy matching estricto para detección de docentes duplicados."""

--- a/utils/Scripts/dataTransfer_v2/core/normalizers.py
+++ b/utils/Scripts/dataTransfer_v2/core/normalizers.py
@@ -36,6 +36,47 @@ CARRERA_MAP = {
     "iif": "IIN",
 }
 
+# Equivalencias para unificar materias con nombres diferentes según la carrera
+EQUIVALENCIAS_ASIGNATURAS = {
+    ## CIENCIAS BASICAS DCB
+    "Fundamentos de Matemática": "Geometría Analítica",                     #iin
+    "Geometría Analítica y Vectores": "Geometría Analítica",
+    "Cálculo Aplicado": "Cálculo VI",                                       #lel
+    "Métodos Numéricos en Ciencias de la Atmósfera": "Métodos Numéricos",   #lca
+    "Termodinámica": "Física IV",                                           #lel
+    "Física Moderna": "Física V",                                           #icm
+    "Mecánica Clásica": "Física I",                                         #iae
+    "Mecánica de Fluidos": "Física VIII",                                   #iek,isp,lca,lel
+    "Química": "Química I",                                                 #iae,iek,iel,ien,isp,lca
+    "Mecánica de Materiales": "Mecánica",                                   #iae
+
+    ## ELECTRONICA (O ELECTRICIDAD NOSE) DEE
+    "Introducción a la Electrónica": "Electrónica I",                       #lel
+    "Sistemas Neumáticos e Hidráulicos": "Sistemas Neumáticos Industriales",#lel
+
+    ## INFORMATICA
+    "Informática Aplicada": "Informática I",                                #iek
+
+    ## DGE (??)
+    "Comunicación Oral y Escrita": "Castellano",                            #iek
+    "Expresión Oral y Escrita": "Castellano",                               #isp,iin,lgh
+    "Comunicación": "Castellano",                                           #lci
+    "Contabilidad I": "Contabilidad",                                       #lgh
+    "Administración I": "Contabilidad",                                     #lcik
+    "Legislación": "Derecho",                                               #isp
+    "Leyes": "Derecho",                                                     #lgh
+    "Administración II": "Economía y Finanzas",                             #lcik
+    "Inglés": "Inglés I",                                                   #iin
+    "Idioma I": "Inglés I",                                                 #iek
+    "Inglés Técnico": "Inglés I",                                           #lcik
+    "Electiva - Inglés Técnico I": "Inglés I",                              #lci
+    "Idioma II": "Inglés II",                                               #iek
+    "Organización, Sistemas y Métodos": "Técnicas de Organización y Métodos", #isp
+    "Administración III": "Técnicas de Organización y Métodos",             #lcik
+    "Costos e Ingeniería Económica": "Ingeniería Económica",                #ien
+}
+
+
 def normalizar_texto(texto: str) -> str:
     """Elimina acentos, convierte a minúsculas, colapsa espacios."""
     if not texto: return ""
@@ -51,6 +92,11 @@ def normalizar_titulo_asignatura(titulo: str) -> str:
     titulo = re.sub(r'\s*[\(\[].*?[\)\]]', '', str(titulo))
     titulo = ' '.join(titulo.split())
     
+    # Mapear equivalencias/sinónimos usando el texto normalizado (minúsculas, sin tildes)
+    titulo_norm = normalizar_texto(titulo)
+    if titulo_norm in EQUIVALENCIAS_ASIGNATURAS:
+        titulo = EQUIVALENCIAS_ASIGNATURAS[titulo_norm]
+
     # 2. Corregir typos (insensible a mayúsculas usando replace)
     for typo, correcto in TYPO_MAP.items():
         # Usar re.IGNORECASE para typps

--- a/utils/Scripts/dataTransfer_v2/services/asignatura_service.py
+++ b/utils/Scripts/dataTransfer_v2/services/asignatura_service.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from core.models import Asignatura, ValidationReport
 from core.interfaces import IAsignaturaRepository
-from core.normalizers import normalizar_titulo_asignatura
+from core.normalizers import normalizar_titulo_asignatura, normalizar_titulo_con_carrera
 
 class AsignaturaService:
     def __init__(self, repo: IAsignaturaRepository):
@@ -23,7 +23,9 @@ class AsignaturaService:
             if depto and depto not in deptos_bd:
                 report.errores.append(f"Fila {idx+2}: Departamento desconocido '{depto}'")
             
-            titulo_norm = normalizar_titulo_asignatura(titulo)
+            titulo_norm = normalizar_titulo_con_carrera(
+                titulo, str(row.get("_hoja_origen", "")).strip().upper()
+            )
             if titulo_norm in titulos_procesados:
                 report.advertencias.append(f"Fila {idx+2}: Asignatura duplicada '{titulo_norm}'")
             titulos_procesados.add(titulo_norm)
@@ -52,7 +54,9 @@ class AsignaturaService:
                 stats["omitidas_dpto_invalido"] += 1
                 continue
                 
-            titulo_norm = normalizar_titulo_asignatura(titulo)
+            titulo_norm = normalizar_titulo_con_carrera(
+                titulo, str(row.get("_hoja_origen", "")).strip().upper()
+            )
             clave = (titulo_norm, depto)
             
             if clave not in asignaturas_unicas:

--- a/utils/Scripts/dataTransfer_v2/services/malla_service.py
+++ b/utils/Scripts/dataTransfer_v2/services/malla_service.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from core.models import Malla
 from core.interfaces import IMallaRepository
-from core.normalizers import normalizar_titulo_asignatura
+from core.normalizers import normalizar_titulo_con_carrera
 
 class MallaService:
     def __init__(self, repo: IMallaRepository):
@@ -33,7 +33,7 @@ class MallaService:
                 stats["omitidos_carrera_inv"] += 1
                 continue
                 
-            asig_norm = normalizar_titulo_asignatura(asig_raw).lower()
+            asig_norm = normalizar_titulo_con_carrera(asig_raw, carrera_raw).lower()
             
             if asig_norm not in mapa_asignaturas:
                 stats["omitidos_asig_inv"] += 1

--- a/utils/Scripts/dataTransfer_v2/services/seccion_service.py
+++ b/utils/Scripts/dataTransfer_v2/services/seccion_service.py
@@ -2,7 +2,7 @@ import pandas as pd
 from core.models import Seccion, Curso, ValidationReport
 from core.interfaces import ISeccionRepository, IDocenteRepository, IAsignaturaRepository
 from core.normalizers import (
-    normalizar_titulo_asignatura,
+    normalizar_titulo_con_carrera,
     normalizar_texto, 
     generar_correo_generico
 )
@@ -29,7 +29,8 @@ class SeccionService:
             if not titulo_raw or titulo_raw.lower() in ("nan", ""):
                 continue
                 
-            titulo_norm = normalizar_titulo_asignatura(titulo_raw)
+            carrera_sigla = str(row.get("_hoja_origen", "")).strip().upper()
+            titulo_norm = normalizar_titulo_con_carrera(titulo_raw, carrera_sigla)
             asig_tuple = self._asig_repo.buscar_por_titulo_normalizado(titulo_norm)
             
             if not asig_tuple:


### PR DESCRIPTION
# feat: sistema de normalización de asignaturas con soporte para nombres ambiguos

## Descripción

Se implementa un sistema de normalización en dos capas para resolver el problema de
asignaturas que usan distintos nombres en el Excel según la carrera, y el caso más complejo
donde el **mismo nombre** representa **contenidos académicos diferentes** dependiendo de la carrera.

No hay cambios en el schema de la base de datos ni en la lógica de inserción.

---

## Cambios

### `utils/Scripts/dataTransfer_v2/core/normalizers.py`

#### 1. `EQUIVALENCIAS_ASIGNATURAS` *(nuevo diccionario)*

Mapea nombres alternativos a un nombre canónico único antes de insertar en la BD.
Cubre 25 asignaturas en 4 departamentos donde distintas carreras usan nombres distintos
para la misma materia:

- **DCB:** `"Fundamentos de Matemática"` → `"Geometría Analítica"`, `"Química"` → `"Química I"`,
  `"Mecánica Clásica"` → `"Física I"`, `"Física Moderna"` → `"Física V"`, etc.
- **DEE:** `"Introducción a la Electrónica"` → `"Electrónica I"`, etc.
- **DGE:** `"Comunicación Oral y Escrita"` / `"Expresión Oral y Escrita"` / `"Comunicación"` → `"Castellano"`,
  `"Idioma I"` / `"Inglés Técnico"` → `"Inglés I"`, `"Estadística I"` / `"Probabilidades y Estadística"` → `"Probabilidad y Estadística"`, etc.

La búsqueda en el diccionario es **insensible a mayúsculas y tildes** (normaliza tanto la
clave del dict como el título entrante antes de comparar).

#### 2. `EQUIVALENCIAS_POR_CARRERA` *(nuevo diccionario)*

Resuelve el caso donde el mismo nombre en el Excel representa **contenidos distintos** según
la carrera, situación que el diccionario global no puede manejar. Indexado por
`(nombre_normalizado_sin_tildes, SIGLA_CARRERA)`:

```
("estadistica", "IEK")  → "Probabilidad y Estadística"   # IEK comparte Materia 1
("estadistica", "LGH")  → "Estadistica LGH LCI"          # LGH tiene contenido diferente
("estadistica", "LCI")  → "Estadistica LGH LCI"          # ídem
("emprendedorismo","IEL")→ "Plan de Negocios"             # IEL tiene Materia 4
("emprendedorismo","IEN")→ "Plan de Negocios"             # ídem
```

#### 3. `normalizar_titulo_con_carrera(titulo, carrera_sigla)` *(nueva función)*

Punto de entrada unificado para la normalización con contexto de carrera. Consulta
primero `EQUIVALENCIAS_POR_CARRERA`; si hay match retorna el nombre canónico directamente.
Si no, delega al flujo estándar `normalizar_titulo_asignatura()`.

#### 4. Fix en la búsqueda de `EQUIVALENCIAS_ASIGNATURAS`

Se corrige la comparación del diccionario para normalizar **también las claves** antes de
comparar (no solo el título entrante), asegurando que funcione correctamente
independientemente de si las claves en el dict tienen o no tildes.

```python
# Antes
if titulo_norm in EQUIVALENCIAS_ASIGNATURAS:

# Después
for clave_original, valor_canonico in EQUIVALENCIAS_ASIGNATURAS.items():
    if normalizar_texto(clave_original) == titulo_norm:
        titulo = valor_canonico
        break
```

---

### `services/asignatura_service.py`, `services/malla_service.py`, `services/seccion_service.py`

Se reemplaza `normalizar_titulo_asignatura()` por `normalizar_titulo_con_carrera()` en los
tres servicios de importación, pasando la sigla de carrera disponible en cada contexto:

- `asignatura_service` y `seccion_service`: usan la columna `_hoja_origen` del DataFrame
  (nombre de la hoja Excel, que coincide con la sigla de carrera).
- `malla_service`: usa `carrera_raw`, ya disponible en el mismo bloque.

---


## Impacto

| Área | Cambio |
|---|---|
| Schema BD | ✅ Sin cambios |
| Lógica de inserción | ✅ Sin cambios |
| Nuevas entradas en BD | `"Estadistica LGH LCI"` (nueva fila en `asignaturas`) |
| Carreras afectadas | IEK, IMK, IIN, IEL, IEN, LGH, LCI |
| Carreras sin efecto colateral | Todas las demás (flujo original intacto) |
